### PR TITLE
Update installation to enable imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
-from setuptools import setup
+from glob import glob
+from setuptools import setup, find_packages
 
-setup(name='sneks',
-      version='0.0.1',
-      install_requires=['gym','numpy','opencv-python'],
-      packages=['sneks']
+setup(
+    name='sneks',
+    version='0.0.2',
+    install_requires=['gym','numpy'],
+    packages=find_packages(),
 )


### PR DESCRIPTION
When installing locally via `pip install {path_to_snek}` it wasn't copying everything as a dependency. Turned out that installation was copying only shallow level since there weren't any explicit references.

The commit updates the setup.py to include everything that's under `snek` and has `__init__.py`. For the same reason the `snek/core` was updated with `__init__.py`.